### PR TITLE
chore: add api_shortname and library_type to repo metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,11 +4,13 @@
   "product_documentation": "https://cloud.google.com/iap/",
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/iap/latest",
   "issue_tracker": "https://github.com/googleapis/nodejs-iap/issues",
-  "release_level": "ga",
+  "release_level": "stable",
   "language": "nodejs",
   "repo": "googleapis/nodejs-iap",
   "distribution_name": "@google-cloud/iap",
   "api_id": "iap.googleapis.com",
   "default_version": "v1",
-  "requires_billing": true
+  "requires_billing": true,
+  "api_shortname": "iap",
+  "library_type": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -12,5 +12,5 @@
   "default_version": "v1",
   "requires_billing": true,
   "api_shortname": "iap",
-  "library_type": ""
+  "library_type": "GAPIC_AUTO"
 }

--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ This library follows [Semantic Versioning](http://semver.org/).
 
 
 
+This library is considered to be **stable**. The code surface will not change in backwards-incompatible ways
+unless absolutely necessary (e.g. because of critical security issues) or with
+an extensive deprecation period. Issues and requests against **stable** libraries
+are addressed with the highest priority.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Identity-Aware Proxy: Node.js Client](https://github.com/googleapis/nodejs-iap)
 
-[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+
 [![npm version](https://img.shields.io/npm/v/@google-cloud/iap.svg)](https://www.npmjs.org/package/@google-cloud/iap)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-iap/main.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-iap)
 
@@ -119,12 +119,6 @@ _Legacy Node.js versions are supported as a best effort:_
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-
-This library is considered to be **General Availability (GA)**. This means it
-is stable; the code surface will not change in backwards-incompatible ways
-unless absolutely necessary (e.g. because of critical security issues) or with
-an extensive deprecation period. Issues and requests against **GA** libraries
-are addressed with the highest priority.
 
 
 


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 